### PR TITLE
Fix reset time not displaying on Windows/Git Bash

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -99,20 +99,22 @@ format_reset_time() {
     epoch=$(iso_to_epoch "$iso_str")
     [ -z "$epoch" ] && return
 
+    local result=""
     case "$style" in
         time)
-            date -j -r "$epoch" +"%l:%M%p" 2>/dev/null | sed 's/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]' || \
-            date -d "@$epoch" +"%l:%M%P" 2>/dev/null | sed 's/^ //; s/\.//g'
+            result=$(date -j -r "$epoch" +"%l:%M%p" 2>/dev/null | sed 's/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%l:%M%P" 2>/dev/null | sed 's/^ //; s/\.//g')
             ;;
         datetime)
-            date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null | sed 's/  / /g; s/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]' || \
-            date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null | sed 's/  / /g; s/^ //; s/\.//g'
+            result=$(date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null | sed 's/  / /g; s/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null | sed 's/  / /g; s/^ //; s/\.//g')
             ;;
         *)
-            date -j -r "$epoch" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]' || \
-            date -d "@$epoch" +"%b %-d" 2>/dev/null
+            result=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d" 2>/dev/null)
             ;;
     esac
+    printf "%s" "$result"
 }
 
 # ── Extract JSON data ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Reset times after the `⟳` symbol are blank on Windows (Git Bash / MSYS2)
- Root cause: `date -j -r` (macOS-only) fails silently, but piped `sed`/`tr` return exit 0, so the GNU `date -d` fallback via `||` never executes
- Fix: capture output into a variable, fall back to `date -d` only when result is empty

## Before (Windows)
```
current ●●●●○○○○○○  44% ⟳
weekly  ●●●●●●○○○○  65% ⟳
```

## After (Windows)
```
current ●●●●○○○○○○  44% ⟳ 2:30pm
weekly  ●●●●●●○○○○  65% ⟳ mar 12, 2:30pm
```

## Test plan
- [x] Verified on Windows 11 with Git Bash — reset times now display correctly
- [x] macOS path (`date -j -r`) is unchanged and still preferred when available