### PR TITLE
Show extra usage reset date inline

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -315,10 +315,8 @@ if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
             extra_reset=$(date -d "$(date +%Y-%m-01) +1 month" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
         fi
 
-        extra_col="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset}"
-        extra_reset_line="${dim}resets ${reset}${white}${extra_reset}${reset}"
+        extra_col="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset} ${dim}⟳${reset} ${white}${extra_reset}${reset}"
         rate_lines+="\n${extra_col}"
-        rate_lines+="\n${extra_reset_line}"
     fi
 fi
 


### PR DESCRIPTION
## Summary

The "current" and "weekly" rate limit lines display their reset time inline with the `⟳` icon, but the "extra" usage line renders its reset date on a separate standalone line. This makes the output inconsistent.

This PR makes the extra line consistent with the others by showing the reset date inline.

### Before

```
current ○○○○○○○○○○   4% ⟳ 3:00am
weekly  ○○○○○○○○○○   9% ⟳ mar 13, 12:00pm
extra   ○○○○○○○○○○ $0.00/$42.50
resets apr 1
```

### After

```
current ○○○○○○○○○○   4% ⟳ 3:00am
weekly  ○○○○○○○○○○   9% ⟳ mar 13, 12:00pm
extra   ○○○○○○○○○○ $0.00/$42.50 ⟳ apr 1
```