### PR TITLE
Fix thundering herd on usage API causing 429 errors

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -259,19 +259,31 @@ if [ -f "$cache_file" ]; then
 fi
 
 if $needs_refresh; then
-    token=$(get_oauth_token)
-    if [ -n "$token" ] && [ "$token" != "null" ]; then
-        response=$(curl -s --max-time 5 \
-            -H "Accept: application/json" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $token" \
-            -H "anthropic-beta: oauth-2025-04-20" \
-            -H "User-Agent: claude-code/2.1.34" \
-            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
-        if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
-            usage_data="$response"
-            echo "$response" > "$cache_file"
+    lock_file="/tmp/claude/statusline-usage.lock"
+    # Remove stale lock file (older than 10 seconds, likely from a killed process)
+    if [ -f "$lock_file" ]; then
+        lock_mtime=$(stat -c %Y "$lock_file" 2>/dev/null || stat -f %m "$lock_file" 2>/dev/null)
+        lock_age=$(( $(date +%s) - lock_mtime ))
+        [ "$lock_age" -gt 10 ] && rm -f "$lock_file"
+    fi
+    if ( set -o noclobber; echo $$ > "$lock_file" ) 2>/dev/null; then
+        trap 'rm -f "$lock_file"' EXIT
+        token=$(get_oauth_token)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            response=$(curl -s --max-time 5 \
+                -H "Accept: application/json" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $token" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "User-Agent: claude-code/2.1.34" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+            if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+                usage_data="$response"
+                echo "$response" > "$cache_file"
+            fi
         fi
+        rm -f "$lock_file"
+        trap - EXIT
     fi
     if [ -z "$usage_data" ] && [ -f "$cache_file" ]; then
         usage_data=$(cat "$cache_file" 2>/dev/null)


### PR DESCRIPTION
## Summary

- When multiple Claude Code sessions share the same usage cache file (`/tmp/claude/statusline-usage-cache.json`), all instances detect cache expiry simultaneously and fire concurrent API requests to `/api/oauth/usage`, triggering HTTP 429 rate limit errors.
- Add a file lock (`noclobber`) so only one process refreshes the cache at a time; other instances fall back to the existing cached data.
- Stale locks (older than 10 seconds) are automatically cleaned up to handle cases where a process was killed without releasing the lock.

## Test plan

- [x] Run 2+ Claude Code sessions simultaneously
- [x] Wait for cache to expire (60s) and verify only one API request is made
- [x] Kill a session mid-refresh, verify the stale lock is cleaned up within 10s
- [x] Confirm rate limit data still displays correctly for all sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)