### PR TITLE
feat: support user color overrides for light theme compatibility

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -9,6 +9,7 @@ if [ -z "$input" ]; then
 fi
 
 # ── Colors ──────────────────────────────────────────────
+# Default palette (optimized for dark terminals)
 blue='\033[38;2;0;153;255m'
 orange='\033[38;2;255;176;85m'
 green='\033[38;2;0;175;80m'
@@ -19,6 +20,13 @@ white='\033[38;2;220;220;220m'
 magenta='\033[38;2;180;140;255m'
 dim='\033[2m'
 reset='\033[0m'
+
+# User color overrides from config file (survives updates)
+color_config="$HOME/.claude/statusline-colors.sh"
+if [ -f "$color_config" ]; then
+    # shellcheck source=/dev/null
+    source "$color_config"
+fi
 
 sep=" ${dim}│${reset} "
 


### PR DESCRIPTION
## Problem

The default `white` color (`rgb(220, 220, 220)`) is invisible on light terminal backgrounds. This affects users on Ghostty light theme, iTerm2 Light Background, Terminal.app default, etc.

**Before (light theme):**
Labels like "current", "weekly", and reset times are completely invisible.

**After:**
Users can create `~/.claude/statusline-colors.sh` with overrides that persist across `npx @kamranahmedse/claude-statusline` updates.

## Solution

Source an optional user config file after setting defaults:

```bash
color_config="$HOME/.claude/statusline-colors.sh"
if [ -f "$color_config" ]; then
    source "$color_config"
fi
```

**Example `~/.claude/statusline-colors.sh` for light theme:**
```bash
white='\033[38;2;130;135;150m'
```

Users can override any color variable (`blue`, `green`, `red`, `yellow`, `white`, `cyan`, `magenta`, `orange`, `dim`).

## Why this approach

- **Zero breaking changes** — no config file = same behavior as before
- **Survives updates** — `npx` overwrites `statusline.sh` but not `statusline-colors.sh`
- **Simple** — just bash `source`, no JSON parsing, no new dependencies
- **Flexible** — any ANSI escape sequence works, not limited to predefined themes

Closes #11