### PR TITLE
Show parent/current directory instead of just basename

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -147,7 +147,15 @@ fi
 pct_color=$(color_for_pct "$pct_used")
 cwd=$(echo "$input" | jq -r '.cwd // ""')
 [ -z "$cwd" ] || [ "$cwd" = "null" ] && cwd=$(pwd)
-dirname=$(basename "$cwd")
+# Show parent/current instead of just basename to avoid ambiguity
+# e.g. "nexus-dashboard/backend" instead of just "backend"
+parent=$(basename "$(command dirname "$cwd")")
+base=$(basename "$cwd")
+if [ "$parent" = "/" ] || [ "$parent" = "." ]; then
+    dirname="$base"
+else
+    dirname="${parent}/${base}"
+fi
 
 git_branch=""
 git_dirty=""


### PR DESCRIPTION
## Summary

- Display two levels of the path (e.g. `nexus-dashboard/backend`) instead of just the basename (`backend`)
- Handles edge cases: root `/` and single-level paths show basename only

## Problem

When working across multiple projects with common folder names like `backend`, `server`, `src`, the statusline only shows the leaf directory — making it impossible to tell which project you're in.

**Before:** `backend`
**After:** `nexus-dashboard/backend`

## Test plan

- [x] Tested with nested paths: `/a/b/c` → `b/c`
- [x] Tested with root: `/` → `/`
- [x] Tested with shallow paths: `/tmp` → `tmp`

Fixes #14