### PR TITLE
Compact rate limits into single-line layout

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -291,7 +291,7 @@ if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
     five_hour_pct_color=$(color_for_pct "$five_hour_pct")
     five_hour_pct_fmt=$(printf "%3d" "$five_hour_pct")
 
-    rate_lines+="${white}current${reset} ${five_hour_bar} ${five_hour_pct_color}${five_hour_pct_fmt}%${reset} ${dim}⟳${reset} ${white}${five_hour_reset}${reset}"
+    rate_lines+="${white}now${reset} ${five_hour_bar} ${five_hour_pct_color}${five_hour_pct_fmt}%${reset} ${dim}⟳ ${reset}${white}${five_hour_reset}${reset}"
 
     seven_day_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
     seven_day_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
@@ -300,7 +300,7 @@ if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
     seven_day_pct_color=$(color_for_pct "$seven_day_pct")
     seven_day_pct_fmt=$(printf "%3d" "$seven_day_pct")
 
-    rate_lines+="\n${white}weekly${reset}  ${seven_day_bar} ${seven_day_pct_color}${seven_day_pct_fmt}%${reset} ${dim}⟳${reset} ${white}${seven_day_reset}${reset}"
+    rate_lines+="${sep}${white}wk${reset}  ${seven_day_bar} ${seven_day_pct_color}${seven_day_pct_fmt}%${reset} ${dim}⟳ ${reset}${white}${seven_day_reset}${reset}"
 
     extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
     if [ "$extra_enabled" = "true" ]; then
@@ -310,18 +310,12 @@ if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
         extra_bar=$(build_bar "$extra_pct" "$bar_width")
         extra_pct_color=$(color_for_pct "$extra_pct")
 
-        extra_reset=$(date -v+1m -v1d +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-        if [ -z "$extra_reset" ]; then
-            extra_reset=$(date -d "$(date +%Y-%m-01) +1 month" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-        fi
-
-        extra_col="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset} ${dim}⟳${reset} ${white}${extra_reset}${reset}"
-        rate_lines+="\n${extra_col}"
+        rate_lines+="${sep}${white}ex${reset}  ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset}"
     fi
 fi
 
 # ── Output ──────────────────────────────────────────────
 printf "%b" "$line1"
-[ -n "$rate_lines" ] && printf "\n\n%b" "$rate_lines"
+[ -n "$rate_lines" ] && printf "\n%b" "$rate_lines"
 
 exit 0


### PR DESCRIPTION
## Summary

- Put **now** (5h) and **wk** (7d) rate limits on the same line, separated by `│`
- Shorten labels: `current` → `now`, `weekly` → `wk`, `extra` → `ex`
- Remove blank line gap between model info and rate limits
- Extra usage also inlined (if enabled)

## Before (3-4 lines)

```
Opus 4.6 │ ✍️ 18% │ myproject │ ◑ default

current ●○○○○○○○○○  10% ⟳ 6:00pm
weekly  ●●●●●○○○○○  53% ⟳ mar 13, 1:00pm
```

## After (2 lines)

```
Opus 4.6 │ ✍️ 18% │ myproject │ ◑ default
now ●○○○○○○○○○  10% ⟳ 6:00pm │ wk  ●●●●●○○○○○  53% ⟳ mar 13, 1:00pm
```

## Why

The statusline occupies significant vertical space in a terminal where every line counts. Stacking rate limits vertically wastes space when they fit comfortably on one line. The shorter labels (`now`/`wk`/`ex`) keep things scannable while saving horizontal space for the actual data.