### PR TITLE
feat: show YOLO mode indicator when --dangerously-skip-permissions is active

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -143,6 +143,18 @@ if [ -f "$settings_path" ]; then
     effort=$(jq -r '.effortLevel // "default"' "$settings_path" 2>/dev/null)
 fi
 
+# ── YOLO mode detection (--dangerously-skip-permissions) ──
+yolo_mode=false
+pid=$$
+for _i in 1 2 3 4 5; do
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -z "$pid" ] || [ "$pid" = "0" ] || [ "$pid" = "1" ] && break
+    if ps -o args= -p "$pid" 2>/dev/null | grep -q "dangerously-skip-permissions"; then
+        yolo_mode=true
+        break
+    fi
+done
+
 # ── LINE 1: Model │ Context % │ Directory (branch) │ Session │ Thinking ──
 pct_color=$(color_for_pct "$pct_used")
 cwd=$(echo "$input" | jq -r '.cwd // ""')
@@ -194,6 +206,10 @@ case "$effort" in
     low)    line1+="${dim}◔ ${effort}${reset}" ;;
     *)      line1+="${dim}◑ ${effort}${reset}" ;;
 esac
+if $yolo_mode; then
+    line1+="${sep}"
+    line1+="${red}⚠ YOLO${reset}"
+fi
 
 # ── OAuth token resolution ──────────────────────────────
 get_oauth_token() {


### PR DESCRIPTION
## Summary

Closes #13 — Adds a red `⚠ YOLO` indicator to the statusline when Claude Code is running with `--dangerously-skip-permissions`.

**Detection method:** Walks up the parent process tree (up to 5 levels) checking for the `--dangerously-skip-permissions` flag in the command line arguments. This is cross-platform (works on both macOS and Linux) and doesn't depend on any specific JSON input field or environment variable.

**Display:** The indicator appears at the end of line 1, after the thinking effort level, using the existing red color and separator style:

```
Claude 3.5 Sonnet │ ✍️ 42% │ myproject (main) │ ⏱ 5m │ ◑ default │ ⚠ YOLO
```

**Changes:** `bin/statusline.sh` only — 16 lines added, 0 removed.

## Test plan

- [x] `bash -n` syntax check passes
- [ ] Manual test: run `claude --dangerously-skip-permissions` and verify `⚠ YOLO` appears
- [ ] Manual test: run `claude` normally and verify no YOLO indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)