### PR TITLE
Use --no-optional-locks for git status check

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -153,7 +153,7 @@ git_branch=""
 git_dirty=""
 if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
-    if [ -n "$(git -C "$cwd" status --porcelain 2>/dev/null)" ]; then
+    if [ -n "$(git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null)" ]; then
         git_dirty="*"
     fi
 fi


### PR DESCRIPTION
## Summary
- Add `--no-optional-locks` flag to the `git status --porcelain` call used for dirty-check
- This prevents the statusline from acquiring the git index lock, avoiding conflicts with concurrent git operations (e.g. `git commit`, `git merge`)

## Test plan
- [ ] Verify statusline still shows `*` when there are uncommitted changes
- [ ] Verify no index.lock conflicts when running git operations while statusline is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)