### PR TITLE
Show worktree branch when running in a git worktree session

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -147,13 +147,21 @@ fi
 pct_color=$(color_for_pct "$pct_used")
 cwd=$(echo "$input" | jq -r '.cwd // ""')
 [ -z "$cwd" ] || [ "$cwd" = "null" ] && cwd=$(pwd)
-dirname=$(basename "$cwd")
+
+# Use worktree path/branch when running inside a git worktree session
+worktree_path=$(echo "$input" | jq -r '.worktree.path // empty')
+if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
+    git_dir="$worktree_path"
+else
+    git_dir="$cwd"
+fi
+dirname=$(basename "$git_dir")
 
 git_branch=""
 git_dirty=""
-if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
-    if [ -n "$(git -C "$cwd" status --porcelain 2>/dev/null)" ]; then
+if git -C "$git_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_branch=$(git -C "$git_dir" symbolic-ref --short HEAD 2>/dev/null)
+    if [ -n "$(git -C "$git_dir" status --porcelain 2>/dev/null)" ]; then
         git_dirty="*"
     fi
 fi


### PR DESCRIPTION
## Summary

- When Claude Code runs inside a git worktree, the statusline JSON includes a `.worktree.path` field. The script now uses this to resolve the git branch and directory name, instead of always using `.cwd` (which reflects the original project directory).
- Falls back to `.cwd` when no worktree is active, so behavior is unchanged for non-worktree sessions.

## Test plan

- [ ] Run Claude Code normally (no worktree) — statusline shows project branch as before
- [ ] Run Claude Code with `--worktree` or via agent worktree dispatch — statusline shows the worktree's branch and directory name

🤖 Generated with [Claude Code](https://claude.com/claude-code)