### PR TITLE
Security hardening: token exposure, cache dir, awk interpolation

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -26,9 +26,9 @@ sep=" ${dim}│${reset} "
 format_tokens() {
     local num=$1
     if [ "$num" -ge 1000000 ]; then
-        awk "BEGIN {printf \"%.1fm\", $num / 1000000}"
+        awk -v n="$num" 'BEGIN {printf "%.1fm", n / 1000000}'
     elif [ "$num" -ge 1000 ]; then
-        awk "BEGIN {printf \"%.0fk\", $num / 1000}"
+        awk -v n="$num" 'BEGIN {printf "%.0fk", n / 1000}'
     else
         printf "%d" "$num"
     fi
@@ -241,9 +241,11 @@ get_oauth_token() {
 }
 
 # ── Fetch usage data (cached) ──────────────────────────
-cache_file="/tmp/claude/statusline-usage-cache.json"
+cache_dir="${XDG_RUNTIME_DIR:-$HOME/.cache}/claude"
+mkdir -p "$cache_dir"
+chmod 700 "$cache_dir"
+cache_file="$cache_dir/statusline-usage-cache.json"
 cache_max_age=60
-mkdir -p /tmp/claude
 
 needs_refresh=true
 usage_data=""
@@ -264,10 +266,10 @@ if $needs_refresh; then
         response=$(curl -s --max-time 5 \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $token" \
             -H "anthropic-beta: oauth-2025-04-20" \
             -H "User-Agent: claude-code/2.1.34" \
-            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+            -H @- \
+            "https://api.anthropic.com/api/oauth/usage" <<< "Authorization: Bearer $token" 2>/dev/null)
         if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
             usage_data="$response"
             echo "$response" > "$cache_file"


### PR DESCRIPTION
## Summary

Fixes three security concerns identified in #29:

- **OAuth token in process listing:** Moved token from curl command-line arg (`-H "Authorization: Bearer $token"`) to stdin via `-H @-` with heredoc, so it no longer appears in `ps aux` output
- **Insecure `/tmp` cache:** Moved cache directory from world-readable `/tmp/claude/` to user-private `$XDG_RUNTIME_DIR` (or `~/.cache/claude` fallback) with `chmod 700`
- **Fragile awk interpolation:** Replaced shell variable interpolation inside double-quoted awk programs with safe `-v` flag binding

## Changes

Only `bin/statusline.sh` is modified, 8 lines added / 6 removed. No behavioral changes — output is identical.

## Test plan

- [ ] Run `npx @kamranahmedse/claude-statusline` with this branch and verify statusline renders correctly
- [ ] Verify cache is created under `~/.cache/claude/` (or `$XDG_RUNTIME_DIR/claude/`) with `700` permissions
- [ ] Verify `ps aux | grep curl` does not show the OAuth token during API call
- [ ] Verify rate limit bars still display correctly

Closes #29