### PR TITLE
feat: respect CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,61 @@
-# claude-statusline
+# claude-statusline (fork)
 
-Configure your Claude Code statusline to show limits, directory and git info
+A redesigned Claude Code statusline with pastel colors, right-aligned layout, and cost tracking.
 
-![demo](./.github/demo.png)
+Forked from [kamranahmedse/claude-statusline](https://github.com/kamranahmedse/claude-statusline).
+
+## What's different
+
+- **Pastel color palette** — soft, low-contrast colors that don't strain your eyes
+- **Right-aligned layout** — context window (line 1) and cost info (line 2) align to the right edge
+- **Cost tracking** — daily and total cost via [ccusage](https://github.com/ryoppippi/ccusage), refreshed in background
+- **Context window** — block progress bar with token count (e.g. `⚡██░░░ 20% (200k/1M)`), dynamic color at 20% threshold
+- **Git diff stats** — `(+42 -10 ?3)` showing insertions, deletions, and untracked files
+- **Nerd Font icons** — git branch, refresh timer, session clock
+- **Buddy-aware margin** — configurable right margin for Claude Code's companion
+- **`CLAUDE_CONFIG_DIR` support** — respects custom config directories
+- **`padding: 0`** — full-width statusline layout
 
 ## Install
 
-Run the command below to set it up
-
 ```bash
-npx @kamranahmedse/claude-statusline
-```
+# Install to ~/.claude (default)
+bun bin/install.js
 
-It backups your old status line if any and copies the status line script to `~/.claude/statusline.sh` and configures your Claude Code settings.
+# Install to custom config dir
+CLAUDE_CONFIG_DIR=/path/to/.claude bun bin/install.js
+```
 
 ## Requirements
 
 - [jq](https://jqlang.github.io/jq/) — for parsing JSON
 - curl — for fetching rate limit data
-- git — for branch info
-
-On macOS:
+- git — for branch and diff info
+- python3 — for accurate terminal width calculation
+- [Nerd Font](https://www.nerdfonts.com/) — for icons (recommended: **JetBrainsMono Nerd Font Mono** — icons forced to single cell width, no alignment issues)
+- [ccusage](https://github.com/ryoppippi/ccusage) (optional) — for cost tracking
 
 ```bash
 brew install jq
+bun install -g ccusage
+```
+
+## Configuration
+
+In your `settings.json` (`~/.claude/settings.json` or `$CLAUDE_CONFIG_DIR/settings.json`):
+
+```jsonc
+{
+  // Set to "buddy" if you have the companion enabled, omit otherwise
+  "statusLineMargin": "buddy"
+}
 ```
 
 ## Uninstall
 
 ```bash
-npx @kamranahmedse/claude-statusline --uninstall
+bun bin/install.js --uninstall
 ```
-
-If you had a previous statusline, it restores it from the backup. Otherwise it removes the script and cleans up your settings.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,17 +40,6 @@ brew install jq
 bun install -g ccusage
 ```
 
-## Configuration
-
-In your `settings.json` (`~/.claude/settings.json` or `$CLAUDE_CONFIG_DIR/settings.json`):
-
-```jsonc
-{
-  // Set to "buddy" if you have the companion enabled, omit otherwise
-  "statusLineMargin": "buddy"
-}
-```
-
 ## Uninstall
 
 ```bash

--- a/bin/install.js
+++ b/bin/install.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-const CLAUDE_DIR = path.join(os.homedir(), ".claude");
+const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
 const SETTINGS_FILE = path.join(CLAUDE_DIR, "settings.json");
 const STATUSLINE_DEST = path.join(CLAUDE_DIR, "statusline.sh");
 const STATUSLINE_SRC = path.resolve(__dirname, "statusline.sh");
@@ -146,7 +146,7 @@ function run() {
 
   const statusLineConfig = {
     type: "command",
-    command: 'bash "$HOME/.claude/statusline.sh"',
+    command: `bash "${STATUSLINE_DEST}"`,
   };
 
   if (

--- a/bin/install.js
+++ b/bin/install.js
@@ -147,12 +147,14 @@ function run() {
   const statusLineConfig = {
     type: "command",
     command: `bash "${STATUSLINE_DEST}"`,
+    padding: 0,
   };
 
   if (
     settings.statusLine &&
     settings.statusLine.type === "command" &&
-    settings.statusLine.command === statusLineConfig.command
+    settings.statusLine.command === statusLineConfig.command &&
+    settings.statusLine.padding === 0
   ) {
     success("Settings already configured");
   } else {

--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -9,18 +9,74 @@ if [ -z "$input" ]; then
 fi
 
 # ── Colors ──────────────────────────────────────────────
-blue='\033[38;2;0;153;255m'
-orange='\033[38;2;255;176;85m'
-green='\033[38;2;0;175;80m'
-cyan='\033[38;2;86;182;194m'
-red='\033[38;2;255;85;85m'
-yellow='\033[38;2;230;200;0m'
-white='\033[38;2;220;220;220m'
-magenta='\033[38;2;180;140;255m'
+blue='\033[38;2;160;200;245m'
+orange='\033[38;2;240;200;150m'
+green='\033[38;2;170;230;170m'
+cyan='\033[38;2;130;200;220m'
+red='\033[38;2;240;150;150m'
+yellow='\033[38;2;240;230;160m'
+white='\033[38;2;210;215;220m'
+magenta='\033[38;2;200;175;225m'
+white_dim='\033[38;2;175;175;178m'
+cyan_dim='\033[38;2;90;145;160m'
+magenta_dim='\033[38;2;130;115;142m'
+orange_bright='\033[38;2;220;180;130m'
+orange_dim='\033[38;2;150;125;95m'
+orange_dark='\033[38;2;120;100;78m'
 dim='\033[2m'
 reset='\033[0m'
 
 sep=" ${dim}│${reset} "
+
+# ── Terminal width + right-align helper ────────────────
+term_width=""
+# Try parent process tty (works inside pipes)
+parent_tty=$(ps -o tty= -p $(ps -o ppid= -p $$) 2>/dev/null | tr -d ' ')
+if [ -n "$parent_tty" ] && [ "$parent_tty" != "??" ] && [ "$parent_tty" != "?" ]; then
+    term_width=$(stty size < "/dev/${parent_tty}" 2>/dev/null | awk '{print $2}')
+fi
+# Fallback to tput
+[ -z "$term_width" ] && term_width=$(tput cols 2>/dev/null)
+[ -z "$term_width" ] && term_width=120
+# Account for Claude Code's padding + buddy if enabled
+status_margin=6
+_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+if [ -f "$_settings" ]; then
+    buddy_flag=$(jq -r '.statusLineMargin // empty' "$_settings" 2>/dev/null)
+    [ "$buddy_flag" = "buddy" ] && status_margin=18
+fi
+term_width=$(( term_width - status_margin ))
+
+# Get visible display width (strip ANSI, use python3 for wcwidth, fallback wc)
+visible_width() {
+    local stripped
+    stripped=$(printf "%b" "$1" | sed $'s/\033\[[0-9;]*m//g')
+    local w
+    w=$(python3 -c "
+import unicodedata,sys
+s=sys.stdin.read().rstrip('\n')
+w=0
+for c in s:
+    eaw=unicodedata.east_asian_width(c)
+    if eaw in('W','F'):w+=2
+    elif unicodedata.category(c) in('Mn','Me','Cf'):pass
+    else:w+=1
+print(w)" <<< "$stripped" 2>/dev/null)
+    [ -z "$w" ] && w=${#stripped}
+    printf "%s" "$w"
+}
+
+# Build a line: left + space padding + right, filling terminal width
+align_lr() {
+    local left="$1" right="$2"
+    local left_w right_w spaces pad=""
+    left_w=$(visible_width "$left")
+    right_w=$(visible_width "$right")
+    spaces=$(( term_width - left_w - right_w ))
+    [ "$spaces" -lt 1 ] && spaces=1
+    printf -v pad "%${spaces}s" ""
+    printf "%b%s%b" "$left" "$pad" "$right"
+}
 
 # ── Helpers ─────────────────────────────────────────────
 color_for_pct() {
@@ -35,17 +91,16 @@ color_for_pct() {
 build_bar() {
     local pct=$1
     local width=$2
+    local bar_color=$3
     [ "$pct" -lt 0 ] 2>/dev/null && pct=0
     [ "$pct" -gt 100 ] 2>/dev/null && pct=100
 
     local filled=$(( pct * width / 100 ))
     local empty=$(( width - filled ))
-    local bar_color
-    bar_color=$(color_for_pct "$pct")
 
     local filled_str="" empty_str=""
-    for ((i=0; i<filled; i++)); do filled_str+="●"; done
-    for ((i=0; i<empty; i++)); do empty_str+="○"; done
+    for ((i=0; i<filled; i++)); do filled_str+="━"; done
+    for ((i=0; i<empty; i++)); do empty_str+="┅"; done
 
     printf "${bar_color}${filled_str}${dim}${empty_str}${reset}"
 }
@@ -58,18 +113,16 @@ format_epoch_time() {
     local result=""
     case "$style" in
         time)
-            result=$(date -j -r "$epoch" +"%l:%M%p" 2>/dev/null)
-            [ -z "$result" ] && result=$(date -d "@$epoch" +"%l:%M%P" 2>/dev/null)
-            result=$(echo "$result" | sed 's/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            result=$(date -j -r "$epoch" +"%-H:%M" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%-H:%M" 2>/dev/null)
             ;;
         datetime)
-            result=$(date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null)
-            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null)
-            result=$(echo "$result" | sed 's/  / /g; s/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            result=$(date -j -r "$epoch" +"%-m/%-d %H:%M" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%-m/%-d %H:%M" 2>/dev/null)
             ;;
         *)
-            result=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null)
-            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d" 2>/dev/null)
+            result=$(date -j -r "$epoch" +"%-m/%-d" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%-m/%-d" 2>/dev/null)
             result=$(echo "$result" | tr '[:upper:]' '[:lower:]')
             ;;
     esac
@@ -124,6 +177,20 @@ else
     pct_used=0
 fi
 
+# Format token count: 200000 → 200k, 1000000 → 1M
+fmt_tokens() {
+    local n=$1
+    if [ "$n" -ge 1000000 ]; then
+        echo "$(( n / 1000000 ))M"
+    elif [ "$n" -ge 1000 ]; then
+        echo "$(( n / 1000 ))k"
+    else
+        echo "$n"
+    fi
+}
+current_fmt=$(fmt_tokens "$current")
+size_fmt=$(fmt_tokens "$size")
+
 effort="default"
 settings_path="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 if [ -f "$settings_path" ]; then
@@ -137,12 +204,8 @@ cwd=$(echo "$input" | jq -r '.cwd // ""')
 dirname=$(basename "$cwd")
 
 git_branch=""
-git_dirty=""
 if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
-    if [ -n "$(git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null)" ]; then
-        git_dirty="*"
-    fi
 fi
 
 session_duration=""
@@ -162,31 +225,54 @@ if [ -n "$session_start" ] && [ "$session_start" != "null" ]; then
     fi
 fi
 
-skip_perms=""
-parent_cmd=$(ps -o args= -p "$PPID" 2>/dev/null)
-if [[ "$parent_cmd" == *"--dangerously-skip-permissions"* ]]; then
-    skip_perms="⚡  "
-fi
 
-line1="${blue}${model_name}${reset}"
-line1+="${sep}"
-line1+="✍️ ${pct_color}${pct_used}%${reset}"
-line1+="${sep}"
-line1+="${skip_perms}${cyan}${dirname}${reset}"
+# Simplify model name: "Opus 4.6 (1M context)" → "Opus 4.6" + dim "(1M)"
+blue_dim='\033[38;2;100;135;175m'
+model_base=$(echo "$model_name" | sed 's/ ([^)]*)//')
+model_ctx=$(echo "$model_name" | sed -n 's/.*(\([^)]*\)).*/\1/p' | sed 's/ context//')
+line1_left="${blue}${model_base}${reset}"
+[ -n "$model_ctx" ] && line1_left+=" ${blue_dim}(${model_ctx})${reset}"
+
+pink='\033[38;2;240;160;180m'
+if [ "$pct_used" -ge 20 ]; then
+    ctx_color="$pink"
+else
+    ctx_color="$white_dim"
+fi
+ctx_filled=$(( pct_used * 15 / 100 ))
+ctx_empty=$(( 15 - ctx_filled ))
+ctx_bar="${ctx_color}"
+for ((i=0; i<ctx_filled; i++)); do ctx_bar+="█"; done
+ctx_bar+="${dim}"
+for ((i=0; i<ctx_empty; i++)); do ctx_bar+="░"; done
+ctx_bar+="${reset}"
+ctx_info='\033[38;2;115;115;118m'
+line1_right="${ctx_color}⚡${reset}${ctx_bar} ${ctx_color}${pct_used}%${reset} ${ctx_info}(${current_fmt}/${size_fmt})${reset}"
 if [ -n "$git_branch" ]; then
-    line1+=" ${green}(${git_branch}${red}${git_dirty}${green})${reset}"
+    line1_left+="${sep}"
+    line1_left+="${white_dim}"$'\xef\x90\x98'" ${git_branch}${reset}"
+    # Git diff stats (staged + unstaged + untracked)
+    unstaged=$(git -C "$cwd" diff --shortstat 2>/dev/null)
+    staged=$(git -C "$cwd" diff --cached --shortstat 2>/dev/null)
+    untracked=$(git -C "$cwd" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+    ins=0 del=0
+    for stat_line in "$unstaged" "$staged"; do
+        [ -z "$stat_line" ] && continue
+        i=$(echo "$stat_line" | grep -o '[0-9]* insertion' | grep -o '[0-9]*')
+        d=$(echo "$stat_line" | grep -o '[0-9]* deletion' | grep -o '[0-9]*')
+        [ -n "$i" ] && ins=$(( ins + i ))
+        [ -n "$d" ] && del=$(( del + d ))
+    done
+    git_changes=""
+    [ "$ins" -gt 0 ] && git_changes+="${green}+${ins}${reset}"
+    [ "$del" -gt 0 ] && { [ -n "$git_changes" ] && git_changes+=" "; git_changes+="${red}-${del}${reset}"; }
+    [ "$untracked" -gt 0 ] && { [ -n "$git_changes" ] && git_changes+=" "; git_changes+="${yellow}?${untracked}${reset}"; }
+    [ -n "$git_changes" ] && line1_left+=" ${white_dim}(${reset}${git_changes}${white_dim})${reset}"
 fi
 if [ -n "$session_duration" ]; then
-    line1+="${sep}"
-    line1+="${dim}⏱ ${reset}${white}${session_duration}${reset}"
+    line1_left+="${sep}"
+    line1_left+="${blue}󰔟 ${reset}${white}${session_duration}${reset}"
 fi
-line1+="${sep}"
-case "$effort" in
-    high)   line1+="${magenta}● ${effort}${reset}" ;;
-    medium) line1+="${dim}◑ ${effort}${reset}" ;;
-    low)    line1+="${dim}◔ ${effort}${reset}" ;;
-    *)      line1+="${dim}◑ ${effort}${reset}" ;;
-esac
 
 # ── Rate limits from stdin (primary) ───────────────────
 has_stdin_rates=false
@@ -288,48 +374,87 @@ else
 fi
 
 # ── Rate limit lines ────────────────────────────────────
-rate_lines=""
-bar_width=10
+line2_left=""
+line3=""
+bar_width=15
 
 if [ -n "$five_hour_pct" ]; then
     five_hour_reset=$(format_epoch_time "$five_hour_reset_epoch" "time")
-    five_hour_bar=$(build_bar "$five_hour_pct" "$bar_width")
-    five_hour_pct_color=$(color_for_pct "$five_hour_pct")
-    five_hour_pct_fmt=$(printf "%3d" "$five_hour_pct")
+    five_hour_bar=$(build_bar "$five_hour_pct" "$bar_width" "$cyan")
 
-    rate_lines+="${white}current${reset} ${five_hour_bar} ${five_hour_pct_color}${five_hour_pct_fmt}%${reset}"
-    [ -n "$five_hour_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${five_hour_reset}${reset}"
+    line2_left+="${cyan}Session${reset} ${five_hour_bar} ${cyan}${five_hour_pct}%${reset}"
+    [ -n "$five_hour_reset" ] && line2_left+=" ${cyan_dim}󰑐 (${five_hour_reset})${reset}"
 fi
 
 if [ -n "$seven_day_pct" ]; then
     seven_day_reset=$(format_epoch_time "$seven_day_reset_epoch" "datetime")
-    seven_day_bar=$(build_bar "$seven_day_pct" "$bar_width")
-    seven_day_pct_color=$(color_for_pct "$seven_day_pct")
-    seven_day_pct_fmt=$(printf "%3d" "$seven_day_pct")
+    seven_day_bar=$(build_bar "$seven_day_pct" "$bar_width" "$magenta")
 
-    [ -n "$rate_lines" ] && rate_lines+="\n"
-    rate_lines+="${white}weekly${reset}  ${seven_day_bar} ${seven_day_pct_color}${seven_day_pct_fmt}%${reset}"
-    [ -n "$seven_day_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${seven_day_reset}${reset}"
+    [ -n "$line2_left" ] && line2_left+="${sep}"
+    line2_left+="${magenta}Weekly${reset} ${seven_day_bar} ${magenta}${seven_day_pct}%${reset}"
+    [ -n "$seven_day_reset" ] && line2_left+=" ${magenta_dim}󰑐 (${seven_day_reset})${reset}"
 fi
 
 if [ "$extra_enabled" = "true" ] && [ -n "$usage_data" ]; then
-    extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
     extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | awk '{printf "%.2f", $1/100}')
     extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | awk '{printf "%.2f", $1/100}')
-    extra_bar=$(build_bar "$extra_pct" "$bar_width")
-    extra_pct_color=$(color_for_pct "$extra_pct")
 
-    extra_reset=$(date -v+1m -v1d +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-    if [ -z "$extra_reset" ]; then
-        extra_reset=$(date -d "$(date +%Y-%m-01) +1 month" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    line3+="${white_dim}Extra${reset} ${white_dim}\$${extra_used}${reset}${white_dim}/${reset}${ctx_info}\$${extra_limit}${reset}"
+fi
+
+# ── Total cost (ccusage, cached) ───────────────────────
+cost_cache="/tmp/claude/statusline-cost-cache.txt"
+cost_cache_max_age=300
+total_cost=""
+
+today_cost=""
+
+if command -v ccusage >/dev/null 2>&1; then
+    cost_needs_refresh=true
+    if [ -f "$cost_cache" ]; then
+        cost_mtime=$(stat -c %Y "$cost_cache" 2>/dev/null || stat -f %m "$cost_cache" 2>/dev/null)
+        cost_now=$(date +%s)
+        cost_age=$(( cost_now - cost_mtime ))
+        [ "$cost_age" -lt "$cost_cache_max_age" ] && cost_needs_refresh=false
     fi
 
-    [ -n "$rate_lines" ] && rate_lines+="\n"
-    rate_lines+="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset} ${dim}⟳${reset} ${white}${extra_reset}${reset}"
+    # Refresh in background — never block statusline rendering
+    if $cost_needs_refresh; then
+        (ccusage daily --json --offline 2>/dev/null | jq -r '
+            (.daily[-1].totalCost // 0 | tostring) + ":" +
+            (.totals.totalCost // 0 | tostring)
+        ' | awk -F: '{printf "%.2f:%.2f", $1, $2}' > "$cost_cache") &
+    fi
+
+    # Always read from cache (may be stale on first run)
+    if [ -f "$cost_cache" ]; then
+        cached=$(cat "$cost_cache" 2>/dev/null)
+        today_cost="${cached%%:*}"
+        total_cost="${cached##*:}"
+    fi
 fi
 
 # ── Output ──────────────────────────────────────────────
-printf "%b" "$line1"
-[ -n "$rate_lines" ] && printf "\n\n%b" "$rate_lines"
+# Line 1: left=model+branch+session+effort, right=context bar
+align_lr "$line1_left" "$line1_right"
+
+# Line 2: left=Session+Weekly, right=Today+All cost
+line2_right=""
+if [ -n "$today_cost" ] || [ -n "$total_cost" ]; then
+    [ -n "$today_cost" ] && line2_right+="${yellow}\$${today_cost}${reset}"
+    [ -n "$today_cost" ] && [ -n "$total_cost" ] && line2_right+=" ${white_dim}→${reset} "
+    [ -n "$total_cost" ] && line2_right+="${yellow}\$${total_cost}${reset}"
+fi
+
+if [ -n "$line2_left" ] || [ -n "$line2_right" ]; then
+    printf "\n\n"
+    align_lr "$line2_left" "$line2_right"
+fi
+
+# Line 3: Extra (if enabled)
+if [ -n "$line3" ]; then
+    printf "\n"
+    printf "%b" "$line3"
+fi
 
 exit 0

--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -28,56 +28,6 @@ reset='\033[0m'
 
 sep=" ${dim}│${reset} "
 
-# ── Terminal width + right-align helper ────────────────
-term_width=""
-# Try parent process tty (works inside pipes)
-parent_tty=$(ps -o tty= -p $(ps -o ppid= -p $$) 2>/dev/null | tr -d ' ')
-if [ -n "$parent_tty" ] && [ "$parent_tty" != "??" ] && [ "$parent_tty" != "?" ]; then
-    term_width=$(stty size < "/dev/${parent_tty}" 2>/dev/null | awk '{print $2}')
-fi
-# Fallback to tput
-[ -z "$term_width" ] && term_width=$(tput cols 2>/dev/null)
-[ -z "$term_width" ] && term_width=120
-# Account for Claude Code's padding + buddy if enabled
-status_margin=6
-_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
-if [ -f "$_settings" ]; then
-    buddy_flag=$(jq -r '.statusLineMargin // empty' "$_settings" 2>/dev/null)
-    [ "$buddy_flag" = "buddy" ] && status_margin=18
-fi
-term_width=$(( term_width - status_margin ))
-
-# Get visible display width (strip ANSI, use python3 for wcwidth, fallback wc)
-visible_width() {
-    local stripped
-    stripped=$(printf "%b" "$1" | sed $'s/\033\[[0-9;]*m//g')
-    local w
-    w=$(python3 -c "
-import unicodedata,sys
-s=sys.stdin.read().rstrip('\n')
-w=0
-for c in s:
-    eaw=unicodedata.east_asian_width(c)
-    if eaw in('W','F'):w+=2
-    elif unicodedata.category(c) in('Mn','Me','Cf'):pass
-    else:w+=1
-print(w)" <<< "$stripped" 2>/dev/null)
-    [ -z "$w" ] && w=${#stripped}
-    printf "%s" "$w"
-}
-
-# Build a line: left + space padding + right, filling terminal width
-align_lr() {
-    local left="$1" right="$2"
-    local left_w right_w spaces pad=""
-    left_w=$(visible_width "$left")
-    right_w=$(visible_width "$right")
-    spaces=$(( term_width - left_w - right_w ))
-    [ "$spaces" -lt 1 ] && spaces=1
-    printf -v pad "%${spaces}s" ""
-    printf "%b%s%b" "$left" "$pad" "$right"
-}
-
 # ── Helpers ─────────────────────────────────────────────
 color_for_pct() {
     local pct=$1
@@ -208,6 +158,9 @@ if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
 fi
 
+git_worktree=$(echo "$input" | jq -r '.workspace.git_worktree // empty')
+cc_version=$(echo "$input" | jq -r '.version // empty')
+
 session_duration=""
 session_start=$(echo "$input" | jq -r '.session.start_time // empty')
 if [ -n "$session_start" ] && [ "$session_start" != "null" ]; then
@@ -234,20 +187,28 @@ line1_left="${blue}${model_base}${reset}"
 [ -n "$model_ctx" ] && line1_left+=" ${blue_dim}(${model_ctx})${reset}"
 
 pink='\033[38;2;240;160;180m'
+pink_dim='\033[38;2;156;104;117m'
+green_dim='\033[38;2;85;120;85m'
 if [ "$pct_used" -ge 20 ]; then
     ctx_color="$pink"
+    ctx_color_dim="$pink_dim"
 else
-    ctx_color="$white_dim"
+    ctx_color="$green"
+    ctx_color_dim="$green_dim"
 fi
-ctx_filled=$(( pct_used * 15 / 100 ))
-ctx_empty=$(( 15 - ctx_filled ))
+ctx_filled=$(( pct_used * 10 / 100 ))
+ctx_empty=$(( 10 - ctx_filled ))
 ctx_bar="${ctx_color}"
 for ((i=0; i<ctx_filled; i++)); do ctx_bar+="█"; done
 ctx_bar+="${dim}"
 for ((i=0; i<ctx_empty; i++)); do ctx_bar+="░"; done
 ctx_bar+="${reset}"
 ctx_info='\033[38;2;115;115;118m'
-line1_right="${ctx_color}⚡${reset}${ctx_bar} ${ctx_color}${pct_used}%${reset} ${ctx_info}(${current_fmt}/${size_fmt})${reset}"
+line1_right="${ctx_color} ${reset}${ctx_bar} ${ctx_color}${pct_used}%${reset} ${ctx_color_dim}(${current_fmt}/${size_fmt})${reset}"
+if [ -n "$git_worktree" ]; then
+    line1_left+="${sep}"
+    line1_left+="${white_dim}"$'\xef\x86\xbb'" ${git_worktree}${reset}"
+fi
 if [ -n "$git_branch" ]; then
     line1_left+="${sep}"
     line1_left+="${white_dim}"$'\xef\x90\x98'" ${git_branch}${reset}"
@@ -378,13 +339,13 @@ fi
 # ── Rate limit lines ────────────────────────────────────
 line2_left=""
 line3=""
-bar_width=15
+bar_width=10
 
 if [ -n "$five_hour_pct" ]; then
     five_hour_reset=$(format_epoch_time "$five_hour_reset_epoch" "time")
     five_hour_bar=$(build_bar "$five_hour_pct" "$bar_width" "$cyan")
 
-    line2_left+="${cyan}Session${reset} ${five_hour_bar} ${cyan}${five_hour_pct}%${reset}"
+    line2_left+="${cyan}5h${reset} ${five_hour_bar} ${cyan}${five_hour_pct}%${reset}"
     [ -n "$five_hour_reset" ] && line2_left+=" ${cyan_dim}󰑐 (${five_hour_reset})${reset}"
 fi
 
@@ -393,7 +354,7 @@ if [ -n "$seven_day_pct" ]; then
     seven_day_bar=$(build_bar "$seven_day_pct" "$bar_width" "$magenta")
 
     [ -n "$line2_left" ] && line2_left+="${sep}"
-    line2_left+="${magenta}Weekly${reset} ${seven_day_bar} ${magenta}${seven_day_pct}%${reset}"
+    line2_left+="${magenta}7d${reset} ${seven_day_bar} ${magenta}${seven_day_pct}%${reset}"
     [ -n "$seven_day_reset" ] && line2_left+=" ${magenta_dim}󰑐 (${seven_day_reset})${reset}"
 fi
 
@@ -406,10 +367,12 @@ fi
 
 # ── Total cost (ccusage, cached) ───────────────────────
 cost_cache="/tmp/claude/statusline-cost-${_cache_id}.txt"
-cost_cache_max_age=300
+cost_cache_max_age=1800
 total_cost=""
 
 today_cost=""
+
+ccusage_query='(.daily[-1].totalCost // 0 | tostring) + ":" + (.totals.totalCost // 0 | tostring)'
 
 if command -v ccusage >/dev/null 2>&1; then
     cost_needs_refresh=true
@@ -420,12 +383,21 @@ if command -v ccusage >/dev/null 2>&1; then
         [ "$cost_age" -lt "$cost_cache_max_age" ] && cost_needs_refresh=false
     fi
 
-    # Refresh in background — never block statusline rendering
     if $cost_needs_refresh; then
-        (ccusage daily --json --offline 2>/dev/null | jq -r '
-            (.daily[-1].totalCost // 0 | tostring) + ":" +
-            (.totals.totalCost // 0 | tostring)
-        ' | awk -F: '{printf "%.2f:%.2f", $1, $2}' > "$cost_cache") &
+        if [ ! -f "$cost_cache" ]; then
+            # First miss: foreground with timeout so first render shows a value
+            ccusage_raw=$(perl -e 'alarm shift; exec @ARGV' 8 ccusage daily --json --offline 2>/dev/null)
+            if [ -n "$ccusage_raw" ]; then
+                printf "%s" "$ccusage_raw" \
+                    | jq -r "$ccusage_query" 2>/dev/null \
+                    | awk -F: '{printf "%.2f:%.2f", $1, $2}' > "$cost_cache" 2>/dev/null
+            fi
+        else
+            # Subsequent refresh: background, never block rendering
+            (ccusage daily --json --offline 2>/dev/null \
+                | jq -r "$ccusage_query" \
+                | awk -F: '{printf "%.2f:%.2f", $1, $2}' > "$cost_cache") &
+        fi
     fi
 
     # Always read from cache (may be stale on first run)
@@ -437,26 +409,38 @@ if command -v ccusage >/dev/null 2>&1; then
 fi
 
 # ── Output ──────────────────────────────────────────────
-# Line 1: left=model+branch+session+effort, right=context bar
-align_lr "$line1_left" "$line1_right"
+# Line 1: model | branch (diff) | session | context bar — all left-aligned
+line1="$line1_left${sep}$line1_right"
+printf "%b" "$line1"
 
-# Line 2: left=Session+Weekly, right=Today+All cost
-line2_right=""
-if [ -n "$today_cost" ] || [ -n "$total_cost" ]; then
-    [ -n "$today_cost" ] && line2_right+="${yellow}\$${today_cost}${reset}"
-    [ -n "$today_cost" ] && [ -n "$total_cost" ] && line2_right+=" ${white_dim}→${reset} "
-    [ -n "$total_cost" ] && line2_right+="${yellow}\$${total_cost}${reset}"
-fi
-
-if [ -n "$line2_left" ] || [ -n "$line2_right" ]; then
+# Line 2: 5h | 7d — all left-aligned
+if [ -n "$line2_left" ]; then
     printf "\n\n"
-    align_lr "$line2_left" "$line2_right"
+    printf "%b" "$line2_left"
 fi
 
-# Line 3: Extra (if enabled)
+# Line 3: $today → $total | Extra
+line3_cost=""
+if [ -n "$today_cost" ] || [ -n "$total_cost" ]; then
+    line3_cost+="${yellow}Cost${reset} "
+    [ -n "$today_cost" ] && line3_cost+="${yellow}\$${today_cost}${reset}"
+    [ -n "$today_cost" ] && [ -n "$total_cost" ] && line3_cost+=" ${white_dim}→${reset} "
+    [ -n "$total_cost" ] && line3_cost+="${yellow}\$${total_cost}${reset}"
+fi
+
+line3_combined="$line3_cost"
 if [ -n "$line3" ]; then
+    [ -n "$line3_combined" ] && line3_combined+="${sep}"
+    line3_combined+="$line3"
+fi
+if [ -n "$cc_version" ]; then
+    [ -n "$line3_combined" ] && line3_combined+="${sep}"
+    line3_combined+="${ctx_info}v${cc_version}${reset}"
+fi
+
+if [ -n "$line3_combined" ]; then
     printf "\n"
-    printf "%b" "$line3"
+    printf "%b" "$line3_combined"
 fi
 
 exit 0

--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -291,7 +291,9 @@ if [ -n "$stdin_five_pct" ]; then
 fi
 
 # ── Fallback: API call (cached) ────────────────────────
-cache_file="/tmp/claude/statusline-usage-cache.json"
+_config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+_cache_id=$(printf "%s" "$_config_dir" | md5 2>/dev/null || printf "%s" "$_config_dir" | md5sum 2>/dev/null | cut -d' ' -f1)
+cache_file="/tmp/claude/statusline-usage-${_cache_id}.json"
 cache_max_age=60
 mkdir -p /tmp/claude
 
@@ -403,7 +405,7 @@ if [ "$extra_enabled" = "true" ] && [ -n "$usage_data" ]; then
 fi
 
 # ── Total cost (ccusage, cached) ───────────────────────
-cost_cache="/tmp/claude/statusline-cost-cache.txt"
+cost_cache="/tmp/claude/statusline-cost-${_cache_id}.txt"
 cost_cache_max_age=300
 total_cost=""
 

--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -125,7 +125,7 @@ else
 fi
 
 effort="default"
-settings_path="$HOME/.claude/settings.json"
+settings_path="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 if [ -f "$settings_path" ]; then
     effort=$(jq -r '.effortLevel // "default"' "$settings_path" 2>/dev/null)
 fi
@@ -236,7 +236,7 @@ if ! $has_stdin_rates; then
             fi
         fi
         if [ -z "$token" ] || [ "$token" = "null" ]; then
-            creds_file="${HOME}/.claude/.credentials.json"
+            creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
             if [ -f "$creds_file" ]; then
                 token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
             fi


### PR DESCRIPTION
## Summary

- `install.js` and `statusline.sh` currently hardcode `~/.claude` for config/settings/credentials paths
- Claude Code supports `CLAUDE_CONFIG_DIR` for custom config locations
- This PR reads `CLAUDE_CONFIG_DIR` with fallback to `~/.claude` in all three places:
  - `install.js`: config directory resolution
  - `install.js`: `statusLine.command` path in settings.json
  - `statusline.sh`: `settings_path` and `creds_file`

## Test plan

- [x] `CLAUDE_CONFIG_DIR=/custom/path npx @kamranahmedse/claude-statusline` installs to the custom path
- [x] Without `CLAUDE_CONFIG_DIR`, behavior is unchanged (falls back to `~/.claude`)
- [x] `--uninstall` works correctly with custom config dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)