### PR TITLE
Fix live effort display in statusline

### DIFF
--- a/bin/statusline.sh
+++ b/bin/statusline.sh
@@ -124,10 +124,13 @@ else
     pct_used=0
 fi
 
-effort="default"
 settings_path="$HOME/.claude/settings.json"
-if [ -f "$settings_path" ]; then
+effort=$(echo "$input" | jq -r '.effort.level // empty' 2>/dev/null)
+if [ -z "$effort" ] && [ -f "$settings_path" ]; then
     effort=$(jq -r '.effortLevel // "default"' "$settings_path" 2>/dev/null)
+fi
+if [ -z "$effort" ] || [ "$effort" = "null" ]; then
+    effort="default"
 fi
 
 # ── LINE 1: Model │ Context % │ Directory (branch) │ Session │ Effort ──
@@ -182,6 +185,8 @@ if [ -n "$session_duration" ]; then
 fi
 line1+="${sep}"
 case "$effort" in
+    max)    line1+="${magenta}● ${effort}${reset}" ;;
+    xhigh)  line1+="${magenta}● ${effort}${reset}" ;;
     high)   line1+="${magenta}● ${effort}${reset}" ;;
     medium) line1+="${dim}◑ ${effort}${reset}" ;;
     low)    line1+="${dim}◔ ${effort}${reset}" ;;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "claude-statusline": "./bin/install.js"
   },
+  "scripts": {
+    "test": "bash test/statusline.test.sh"
+  },
   "keywords": [
     "claude",
     "claude-code",

--- a/test/statusline.test.sh
+++ b/test/statusline.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+script="$repo_root/bin/statusline.sh"
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+tmp_home=$(mktemp -d)
+cleanup() {
+    if command -v trash >/dev/null 2>&1; then
+        trash "$tmp_home" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_home/.claude"
+printf '{"effortLevel":"xhigh"}\n' > "$tmp_home/.claude/settings.json"
+
+input=$(cat <<JSON
+{
+  "model": {"display_name": "Claude Opus"},
+  "effort": {"level": "max"},
+  "context_window": {
+    "context_window_size": 200000,
+    "current_usage": {
+      "input_tokens": 1000,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0
+    }
+  },
+  "cwd": "$repo_root",
+  "rate_limits": {
+    "five_hour": {"used_percentage": 12, "resets_at": 1792929600},
+    "seven_day": {"used_percentage": 25, "resets_at": 1793361600}
+  }
+}
+JSON
+)
+
+output=$(HOME="$tmp_home" bash "$script" <<< "$input")
+
+case "$output" in
+    *"max"*) ;;
+    *) fail "expected statusline to display live effort level 'max'; got: $output" ;;
+esac
+
+case "$output" in
+    *"xhigh"*) fail "expected stdin effort to override settings effort; got: $output" ;;
+esac
+
+printf 'PASS: statusline displays live max effort\n'

--- a/test/statusline.test.sh
+++ b/test/statusline.test.sh
@@ -13,6 +13,8 @@ tmp_home=$(mktemp -d)
 cleanup() {
     if command -v trash >/dev/null 2>&1; then
         trash "$tmp_home" >/dev/null 2>&1 || true
+    else
+        rm -R "$tmp_home" >/dev/null 2>&1 || true
     fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
## What

Fix the statusline effort indicator so it reflects the live Claude Code session effort level.

The script now reads `effort.level` from the JSON payload Claude Code sends to the statusline command, then falls back to `~/.claude/settings.json` for older payloads or models that do not report effort. It also renders the supported `xhigh` and session-only `max` levels explicitly.

## Why

`max` effort can be selected for the current session with `/effort` or `--effort`, but it is not persisted in `settings.effortLevel`. The previous implementation only read `settings.effortLevel`, so a session running at `max` could still show the persisted/default level in the custom statusline.

## Changes

- Prefer live `.effort.level` from statusline stdin over persisted settings.
- Keep `settings.effortLevel` as a fallback for compatibility.
- Add display cases for `max` and `xhigh`.
- Add a shell regression test where settings contain `xhigh`, stdin contains `max`, and the statusline must display `max`.
- Add `npm test` as the project test entrypoint.

## How to Review

Start with `bin/statusline.sh`: the effort resolution block is the behavior change, and the display `case` adds the new supported levels.

Then review `test/statusline.test.sh`: it captures the regression by proving live stdin effort overrides persisted settings.

## Testing

- `npm test`
- `bash -n bin/statusline.sh test/statusline.test.sh`

## Risk / Deployment Notes

Low risk. This is a display-only change in the statusline script. No settings migration, dependencies, or runtime service changes are required.
